### PR TITLE
prevented pylint testing files outside of source

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Analyze the code with pylint
         run: |
           export PYTHONPATH=$PYTHONPATH:$(pwd)
-          pylint $(git ls-files '*.py')
+          pylint $(git ls-files 'src/*.py')


### PR DESCRIPTION
בטסטים של pylint עושים לינט גם עם קבצים שלא נכתבו על ידינו. זה פותר את זה